### PR TITLE
Incorporating logging and configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For the XMPP notification feature, `python-xmpp` needs to be installed.
 
 ## Role varibles
 
-```
+```yml
 # User and group for bind
 bind9_user: bind
 bind9_group: bind
@@ -92,6 +92,13 @@ bind9_packages:
     - bind9
     - dnsutils
     - haveged
+
+# Logging
+bind9_logging_enable: false
+bind9_log_path: /var/log/bind
+bind9_log_severity: warning  # critical | error | warning | notice | info | debug [ level ] | dynamic
+bind9_log_versions: 3
+bind9_log_size: 60m           # Time units
 ```
 
 Testing & Development

--- a/README.md
+++ b/README.md
@@ -94,11 +94,25 @@ bind9_packages:
     - haveged
 
 # Logging
-bind9_logging_enable: false
+bind9_named_logging: False
 bind9_log_path: /var/log/bind
 bind9_log_severity: warning  # critical | error | warning | notice | info | debug [ level ] | dynamic
 bind9_log_versions: 3
 bind9_log_size: 60m           # Time units
+
+bind9_log_categories:
+  - name: default
+    destination: bind_log
+  - name: update
+    destination: bind_log
+  - name: update-security
+    destination: bind_log
+  - name: security
+    destination: default_syslog
+  - name: queries
+    destination: bind_log
+  - name: lame-servers
+    destination: 'null'
 ```
 
 Testing & Development

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,3 +77,10 @@ bind9_packages:
     - bind9
     - dnsutils
     - haveged
+
+# Logging
+bind9_logging_enable: false
+bind9_log_path: /var/log/bind
+bind9_log_severity: warning  # critical | error | warning | notice | info | debug [ level ] | dynamic
+bind9_log_versions: 3
+bind9_log_size: 60m           # Time units

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -79,8 +79,22 @@ bind9_packages:
     - haveged
 
 # Logging
-bind9_logging_enable: false
+bind9_named_logging: False
 bind9_log_path: /var/log/bind
 bind9_log_severity: warning  # critical | error | warning | notice | info | debug [ level ] | dynamic
 bind9_log_versions: 3
 bind9_log_size: 60m           # Time units
+
+bind9_log_categories:
+  - name: default
+    destination: bind_log
+  - name: update
+    destination: bind_log
+  - name: update-security
+    destination: bind_log
+  - name: security
+    destination: default_syslog
+  - name: queries
+    destination: bind_log
+  - name: lame-servers
+    destination: 'null'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,7 @@
         owner: root
         group: "{{ bind9_group }}"
         mode: 0644
-  when: bind9_logging_enable
+  when: bind9_named_logging
 
 - name: configure bind9 named.conf files
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,24 @@
   notify:
     - restart bind9
 
+- block:
+    - name: ensure existence of the log directory
+      file:
+        path: "{{ bind9_log_path }}"
+        state: directory
+        owner: "{{ bind9_user }}"
+        group: "{{ bind9_group }}"
+        mode: 0755
+
+    - name: configure log rotate for bind9
+      template:
+        src: logrotate.d/bind.j2
+        dest: /etc/logrotate.d/bind
+        owner: root
+        group: "{{ bind9_group }}"
+        mode: 0644
+  when: bind9_logging_enable
+
 - name: configure bind9 named.conf files
   template:
     src: bind/{{ item }}.j2

--- a/templates/bind/named.conf.options.j2
+++ b/templates/bind/named.conf.options.j2
@@ -84,7 +84,7 @@ acl our_neighbors {
 {% endif %}
 };
 
-{% if bind9_logging_enable %}
+{% if bind9_named_logging %}
 logging {
   channel bind_log {
     file "{{ bind9_log_path }}/bind.log" versions {{ bind9_log_versions }} size {{ bind9_log_size }};
@@ -93,11 +93,8 @@ logging {
     print-severity yes;
     print-time yes;
   };
-  category default { bind_log; };
-  category update { bind_log; };
-  category update-security { bind_log; };
-  category security { bind_log; };
-  category queries { bind_log; };
-  category lame-servers { null; };
+  {% for category in bind9_log_categories %}
+  category {{ category.name }} { {{ category.destination }}; };
+  {% endfor %}
 };
 {% endif %}

--- a/templates/bind/named.conf.options.j2
+++ b/templates/bind/named.conf.options.j2
@@ -83,3 +83,21 @@ acl our_neighbors {
 {%   endfor %}
 {% endif %}
 };
+
+{% if bind9_logging_enable %}
+logging {
+  channel bind_log {
+    file "{{ bind9_log_path }}/bind.log" versions {{ bind9_log_versions }} size {{ bind9_log_size }};
+    severity {{ bind9_log_severity }};
+    print-category yes;
+    print-severity yes;
+    print-time yes;
+  };
+  category default { bind_log; };
+  category update { bind_log; };
+  category update-security { bind_log; };
+  category security { bind_log; };
+  category queries { bind_log; };
+  category lame-servers { null; };
+};
+{% endif %}

--- a/templates/logrotate.d/bind.j2
+++ b/templates/logrotate.d/bind.j2
@@ -1,0 +1,12 @@
+{{ bind9_log_path }}/bind.log {
+  daily
+  missingok
+  rotate 7
+  compress
+  delaycompress
+  notifempty
+  create 644 bind bind
+  postrotate
+    /usr/sbin/invoke-rc.d bind9 reload > /dev/null
+  endscript
+}


### PR DESCRIPTION
Hi, first of all thanks for sharing.

In our organization we used this role a while ago. Recently we were experiencing some problems with Bind. Analyzing the causes we noticed that Bind's logging was in the default configuration, registering only high severity issues to the `syslog`.

We add to the role the enablement of Bind's own log and some parameterized configurations. And this feature is what we propose in this PR.
