### PR TITLE
CAA records

### DIFF
--- a/templates/bind/zones/db.template.j2
+++ b/templates/bind/zones/db.template.j2
@@ -12,6 +12,7 @@
   mx_records:
     - priority: 10
       name: mx1.example.org.
+  caa_record: issue "example-ca.org"
   rrs:
     - label: subdomain
       type: A|CNAME|...
@@ -51,6 +52,12 @@ $TTL {{ zone.negative_ttl|default('3600') }}   ; 1 hour
 {%   for txt in zone.txt_records %}
                     TXT     "{{ txt }}"
 {%   endfor %}
+{# CAA record is being used to specify a CA for this domain.
+   Only this CA can create certificates for the domain.
+   Also see: https://www.rfc-editor.org/rfc/rfc8659.html #}
+{% endif %}
+% if zone.caa_record is defined %}
+                    CAA     0 {{ zone.caa_record }}
 {% endif %}
 $ORIGIN {{ zone.name }}.
 

--- a/templates/bind/zones/db.template.j2
+++ b/templates/bind/zones/db.template.j2
@@ -52,11 +52,12 @@ $TTL {{ zone.negative_ttl|default('3600') }}   ; 1 hour
 {%   for txt in zone.txt_records %}
                     TXT     "{{ txt }}"
 {%   endfor %}
+{% endif %}
 {# CAA record is being used to specify a CA for this domain.
    Only this CA can create certificates for the domain.
    Also see: https://www.rfc-editor.org/rfc/rfc8659.html #}
-{% endif %}
-% if zone.caa_record is defined %}
+
+{% if zone.caa_record is defined %}
                     CAA     0 {{ zone.caa_record }}
 {% endif %}
 $ORIGIN {{ zone.name }}.

--- a/templates/bind/zones/db.template.j2
+++ b/templates/bind/zones/db.template.j2
@@ -12,7 +12,8 @@
   mx_records:
     - priority: 10
       name: mx1.example.org.
-  caa_record: issue "example-ca.org"
+  caa_records: 
+    - 0 issue "example-ca.org"
   rrs:
     - label: subdomain
       type: A|CNAME|...
@@ -56,9 +57,10 @@ $TTL {{ zone.negative_ttl|default('3600') }}   ; 1 hour
 {# CAA record is being used to specify a CA for this domain.
    Only this CA can create certificates for the domain.
    Also see: https://www.rfc-editor.org/rfc/rfc8659.html #}
-
-{% if zone.caa_record is defined %}
-                    CAA     0 {{ zone.caa_record }}
+{% if zone.caa_records is defined %}
+{%   for caa in zone.caa_records %}
+                    CAA     {{ caa }}
+{%   endfor %}
 {% endif %}
 $ORIGIN {{ zone.name }}.
 


### PR DESCRIPTION
Add support for a CAA record for a whole domain.

CAA record is being used to specify a CA for this domain.
Only this CA can create certificates for the domain.

Also see: https://www.rfc-editor.org/rfc/rfc8659.html