### PR TITLE
add option to configure statistics-channels

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,6 +56,9 @@ bind9_rndc_algorithm: hmac-md5
 # bind9_slaves:
 #  - 1.2.3.4
 
+# Enable BIND's XML statistics-channels (for monitoring purposes)
+bind9_statistics_enabled: False
+
 # DNS zones
 # bind9_zone_dynamic: zone files created from template (see
 #         `templates/bind/zones/db.template.j2` for yaml structure)

--- a/templates/bind/named.conf.local.j2
+++ b/templates/bind/named.conf.local.j2
@@ -25,6 +25,12 @@ masters {{ master.name }} {
 {%   endfor %}
 {% endif %}
 
+{% if bind9_statistics_enabled %}
+statistics-channels {
+  inet 127.0.0.1 port 8053 allow { 127.0.0.1; };
+};
+{% endif %}
+
 // The following zones are managed by this DNS Server //
 {% for zone in (bind9_zones_static + bind9_zones_dynamic)|sort(attribute='name') %}
 {% set zone_type = zone.type|default(bind9_zone_type|default('master')) %}


### PR DESCRIPTION
Add new variable `bind9_statistics_enabled` to enable binds statistics-channels for exporting metrics.