### PR TITLE
make qname-minimization configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,9 @@ bind9_forward: no
 # Setup DNSSEC for recursor and zones?
 bind9_dnssec: no
 
+# set QNAME minimization behavior in the BIND resolver; atm bind9 default is relaxed
+bind9_qname_minimization: "relaxed"
+
 # DNSSEC validation mode (yes/no/auto)
 bind9_dnssec_validation: "auto"
 

--- a/templates/bind/named.conf.options.j2
+++ b/templates/bind/named.conf.options.j2
@@ -23,9 +23,9 @@ options {
 	// you will need to update your keys.  See https://www.isc.org/bind-keys
 	//========================================================================
 	dnssec-validation {{ bind9_dnssec_validation }};
-
+{% if ansible_distribution_major_version|int >= '11'  %}
 	qname-minimization {{ bind9_qname_minimization }};
-
+{% endif %}
 	auth-nxdomain no;    # conform to RFC1035
 	listen-on-v6 { any; };
 

--- a/templates/bind/named.conf.options.j2
+++ b/templates/bind/named.conf.options.j2
@@ -23,7 +23,7 @@ options {
 	// you will need to update your keys.  See https://www.isc.org/bind-keys
 	//========================================================================
 	dnssec-validation {{ bind9_dnssec_validation }};
-{% if ansible_distribution_major_version|int >= '11'  %}
+{% if ansible_distribution_major_version|int >= 11  %}
 	qname-minimization {{ bind9_qname_minimization }};
 {% endif %}
 	auth-nxdomain no;    # conform to RFC1035

--- a/templates/bind/named.conf.options.j2
+++ b/templates/bind/named.conf.options.j2
@@ -24,6 +24,8 @@ options {
 	//========================================================================
 	dnssec-validation {{ bind9_dnssec_validation }};
 
+	qname-minimization {{ bind9_qname_minimization }};
+
 	auth-nxdomain no;    # conform to RFC1035
 	listen-on-v6 { any; };
 


### PR DESCRIPTION
The bind9 version in debian bullseye supports "qname-minimization":

> qname-minimization
>
>    This option controls QNAME minimization behavior in the BIND resolver. When set to strict, BIND follows the QNAME minimization algorithm to the letter, as specified in RFC 7816. Setting this option to relaxed causes BIND to fall back to normal (non-minimized) query mode when it receives either NXDOMAIN or other unexpected responses (e.g., SERVFAIL, improper zone cut, REFUSED) to a minimized query. disabled disables QNAME minimization completely. The current default is relaxed, but it may be changed to strict in a future release.  [1]

This PR makes this option configurable with the default set to the bind9 default.

[1] https://bind9.readthedocs.io/en/v9_16_22/reference.html