### PR TITLE
remove haveged from bind9_packages

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -110,7 +110,6 @@ bind9_monit_enabled: no
 bind9_packages:
   - bind9
   - dnsutils
-  - haveged
 
 # Directory for bind9 files templates
 bind9_templates: ""


### PR DESCRIPTION
not needed on modern linux kernel anymore, entropy generation is much improved, see https://twitter.com/DanielMicay/status/1396956516020805633