### PR TITLE
Fix DDNS keyfile creation, configuration and writeable zone location

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,30 @@ And similarly `zone_my_reverse_inaddr_arpa` and `zone_my_reverse_ip6_arpa` for I
 
 * deploy role to your servers
 
+### DDNS updates
+
+## Key generation
+
+If you want to have your DDNS keys created by this role configure `bind9_generate_ddns_key`:
+
+```yaml
+-  bind9_generate_ddns_key: true
+```
+
+Keys will by default be stored to `files/bind/zones` withinin your playbook location, but you can customize this with `bind9_local_keydir`
+
+```yaml
+-  bind9_local_keydir: true
+```
+
+## Zone database
+
+Please note that for DDNS updates to work, the location of the zone files needs to be writable by the BIND process.
+Linux distros with Mandatory Access Control (Apparmor, SELinux) ususally don't allow writing to the default `/etc/bind/zones` path. In order to circumvent this you may want to change the zone files location to `/var/lib/bind/zones` instead:
+
+```yaml
+-  bind9_zonedir: /var/lib/bind/zones
+```
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ If you want to have your DDNS keys created by this role configure `bind9_generat
 Keys will by default be stored to `files/bind/zones` withinin your playbook location, but you can customize this with `bind9_local_keydir`
 
 ```yaml
--  bind9_local_keydir: true
+-  bind9_local_keydir: credentials/bind
 ```
 
 ## Zone database

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -138,4 +138,6 @@ bind9_log_categories:
   - name: lame-servers
     destination: 'null'
 
-bind9_zonedir: /var/lib/bind/zones
+bind9_generate_ddns_key: true
+bind9_zonedir: /etc/bind/zones
+bind9_local_keydir: files/bind/zones

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -137,3 +137,5 @@ bind9_log_categories:
     destination: bind_log
   - name: lame-servers
     destination: 'null'
+
+bind9_zonedir: /var/lib/bind/zones

--- a/tasks/create_ddns_keys.yml
+++ b/tasks/create_ddns_keys.yml
@@ -2,7 +2,7 @@
   become: false
   delegate_to: localhost
   stat:
-    path: bind/zones/{{ item.update_keyfile }}.private
+    path: "{{ bind9_local_keydir }}/{{ item.update_keyfile }}.private"
   register: update_keyfile_tmp
   when: item.update_keyfile is defined
 
@@ -16,7 +16,7 @@
 - name: copy DDNS key to control host
   fetch:
     src: "/etc/bind/keys/{{ item.update_keyfile }}.private"
-    dest: bind/zones/{{ item.update_keyfile }}.private
+    dest: "{{ bind9_local_keydir }}/{{ item.update_keyfile }}.private"
     flat: true
   when: ddns_key.changed
 
@@ -24,6 +24,6 @@
   become: false
   delegate_to: localhost
   file:
-    path: bind/zones/{{ item.update_keyfile }}.key
+    path: "{{ bind9_local_keydir }}/{{ item.update_keyfile }}.key"
     state: touch
   when: ddns_key.changed

--- a/tasks/create_ddns_keys.yml
+++ b/tasks/create_ddns_keys.yml
@@ -4,14 +4,14 @@
   stat:
     path: bind/zones/{{ item.update_keyfile }}.private
   register: update_keyfile_tmp
-  when: item.update_keyfile | d(false)
+  when: item.update_keyfile is defined
 
 - name: generate DDNS key
   shell: "tsig-keygen -a {{ item.update_key_algorithm | d('hmac-sha512') }} {{ item.name }}_{{ item.update_keyfile }}_update > /etc/bind/keys/{{ item.update_keyfile }}.private"
   args:
     chdir: "{{ bind9_zonedir }}"
   register: ddns_key
-  when: not update_keyfile_tmp.stat.exists
+  when: item.update_keyfile is defined and not update_keyfile_tmp.stat.exists
 
 - name: copy DDNS key to control host
   fetch:

--- a/tasks/create_ddns_keys.yml
+++ b/tasks/create_ddns_keys.yml
@@ -1,0 +1,29 @@
+- name: determine if DDNS key already exists
+  become: false
+  delegate_to: localhost
+  stat:
+    path: bind/zones/{{ item.update_keyfile }}.private
+  register: update_keyfile_tmp
+  when: item.update_keyfile | d(false)
+
+- name: generate DDNS key
+  shell: "tsig-keygen -a {{ item.update_key_algorithm | d('hmac-sha512') }} {{ item.name }}_{{ item.update_keyfile }}_update > /etc/bind/keys/{{ item.update_keyfile }}.private"
+  args:
+    chdir: "{{ bind9_zonedir }}"
+  register: ddns_key
+  when: not update_keyfile_tmp.stat.exists
+
+- name: copy DDNS key to control host
+  fetch:
+    src: "/etc/bind/keys/{{ item.update_keyfile }}.private"
+    dest: bind/zones/{{ item.update_keyfile }}.private
+    flat: true
+  when: ddns_key.changed
+
+- name: create dummy DDNS public key file on control host
+  become: false
+  delegate_to: localhost
+  file:
+    path: bind/zones/{{ item.update_keyfile }}.key
+    state: touch
+  when: ddns_key.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,7 @@
 - include_tasks: create_ddns_keys.yml
   with_items:
     - "{{ bind9_zones_static + bind9_zones_dynamic }}"
-    
+
 - name: Configure bind9 named.conf files
   template:
     src: "{{ bind9_templates | default('') }}bind/{{ item }}.j2"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,6 +38,7 @@
 - include_tasks: create_ddns_keys.yml
   with_items:
     - "{{ bind9_zones_static + bind9_zones_dynamic }}"
+  when: bind9_generate_ddns_key | bool
 
 - name: Configure bind9 named.conf files
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,10 @@
         mode: 0644
   when: bind9_named_logging
 
+- include_tasks: create_ddns_keys.yml
+  with_items:
+    - "{{ bind9_zones_static + bind9_zones_dynamic }}"
+    
 - name: configure bind9 named.conf files
   template:
     src: "{{ bind9_templates | default('') }}bind/{{ item }}.j2"
@@ -61,7 +65,7 @@
 
 - name: create bind9 directory for master zones
   file:
-    path: /etc/bind/zones
+    path: "{{ bind9_zonedir }}"
     state: directory
     owner: root
     group: "{{ bind9_group }}"
@@ -70,7 +74,7 @@
 
 - name: create bind9 directory for master zone includes
   file:
-    path: /etc/bind/zones/includes
+    path: "{{ bind9_zonedir }}/includes"
     state: directory
     owner: root
     group: "{{ bind9_group }}"
@@ -80,7 +84,7 @@
 - name: install bind9 authoritative include files
   template:
     src: "bind/zones/includes/{{ item }}.j2"
-    dest: "/etc/bind/zones/includes/{{ item }}"
+    dest: "{{ bind9_zonedir }}/includes/{{ item }}"
     owner: root
     group: "{{ bind9_group }}"
     mode: 0644
@@ -299,7 +303,7 @@
 - name: create dynamic bind9 zone files
   template:
     src: "{{ bind9_templates | default('') }}bind/zones/db.template.j2"
-    dest: /etc/bind/zones/db.{{ item.name }}
+    dest: "{{ bind9_zonedir }}/db.{{ item.name }}"
     owner: root
     group: "{{ bind9_group }}"
     mode: 0644
@@ -316,7 +320,7 @@
 - name: install static bind9 zone files
   copy:
     src: bind/zones/db.{{ item.name }}
-    dest: /etc/bind/zones/db.{{ item.name }}
+    dest: "{{ bind9_zonedir }}/db.{{ item.name }}"
     owner: root
     group: "{{ bind9_group }}"
     mode: 0644
@@ -332,7 +336,7 @@
     - role:bind9:zones
 
 - name: check validity of zone files
-  command: named-checkzone {{ item.name }} /etc/bind/zones/db.{{ item.name }}
+  command: named-checkzone {{ item.name }} {{ bind9_zonedir }}/db.{{ item.name }}
   register: bind9_reg_named_checkzone
   become: true
   become_user: "{{ bind9_user }}"

--- a/templates/bind/named.conf.local.j2
+++ b/templates/bind/named.conf.local.j2
@@ -37,7 +37,7 @@ statistics-channels {
 zone "{{ zone.name }}" {
     type {{ zone_type }};
 {%   if zone_type == 'master' %}
-    file "/etc/bind/zones/db.{{ zone.name }}";
+    file "{{ bind9_zonedir }}/db.{{ zone.name }}";
 {%     if bind9_notify_explicit|default() %}
     notify explicit;
 {%     elif zone.notify|default(true) %}

--- a/templates/bind/named.conf.options.j2
+++ b/templates/bind/named.conf.options.j2
@@ -64,10 +64,21 @@ options {
 {%       if loop.first %}
 // The following keys are used for dynamic DNS updates
 {%       endif %}
-key "{{ zone.name }}_ddns_update" {
-	algorithm {{ zone.update_key_algorithm|default('hmac-sha512') }};
-	secret "{{ zone.update_key_secret|default() }}";
-};
+// key "{{ zone.name }}_ddns_update" {
+//	algorithm {{ zone.update_key_algorithm|default('hmac-sha512') }};
+//	secret "{{ zone.update_key_secret|default() }}";
+//};
+{%     endif %}
+{%   endfor %}
+{% endif %}
+
+{% if bind9_zones_static|selectattr('update_keyfile','defined')|list|default() %}
+{%   for zone in bind9_zones_static|selectattr('update_keyfile','defined')|list|default([]) %}
+{%     if zone_type|default(bind9_zone_type|default('master')) == 'master' %}
+{%       if loop.first %}
+// The following keys are used for dynamic DNS updates
+{%       endif %}
+{{ lookup('file', 'bind/zones/'+zone.update_keyfile+'.private') }}
 {%     endif %}
 {%   endfor %}
 {% endif %}

--- a/templates/bind/named.conf.options.j2
+++ b/templates/bind/named.conf.options.j2
@@ -58,16 +58,16 @@ options {
 {% endif %}
 };
 
-{% if bind9_zones_static|selectattr('update_keyfile','defined')|list|default() %}
-{%   for zone in bind9_zones_static|selectattr('update_keyfile','defined')|list|default([]) %}
+{% if bind9_zones_static|selectattr('update_key_secret','defined')|list|default() %}
+{%   for zone in bind9_zones_static|selectattr('update_key_secret','defined')|list|default([]) %}
 {%     if zone_type|default(bind9_zone_type|default('master')) == 'master' %}
 {%       if loop.first %}
 // The following keys are used for dynamic DNS updates
 {%       endif %}
-// key "{{ zone.name }}_ddns_update" {
-//	algorithm {{ zone.update_key_algorithm|default('hmac-sha512') }};
-//	secret "{{ zone.update_key_secret|default() }}";
-//};
+key "{{ zone.name }}_ddns_update" {
+	algorithm {{ zone.update_key_algorithm|default('hmac-sha512') }};
+	secret "{{ zone.update_key_secret|default() }}";
+};
 {%     endif %}
 {%   endfor %}
 {% endif %}


### PR DESCRIPTION
### Problem
This Ansible role writes zone files to a hard coded `/etc/bind/zones` directory, which causes problems on systems with mandatory access control such as Apparmor. The profile for Apparmor does not allow the BIND process to create the necessary journal files and update the zone files under `/etc/bind/zones`.
### Solution
Parameterize the zone directory and default to `/var/lib/bind/zones`, for which write access is allowed by the Apparmor profile.
### PR
This PR parameterises the location for storing the zone files. It also includes code to generate DDNS keys using `tsig-keygen` if a configured `update_keyfile` does not exist already. Since `tsig-keygen` generates a full `key` configuration section, the `named.conf.options.j2` template has been adjusted accordingly.