### PR TITLE
Properly copy generated ddns key to control host

### DIFF
--- a/tasks/create_ddns_keys.yml
+++ b/tasks/create_ddns_keys.yml
@@ -8,16 +8,16 @@
   when: item.update_keyfile is defined
 
 - name: Generate DDNS key
-  ansible.builtin.shell: "tsig-keygen -a {{ item.update_key_algorithm | d('hmac-sha512') }} {{ item.name }}_{{ item.update_keyfile }}_update > /etc/bind/keys/{{ item.update_keyfile }}.private"
+  ansible.builtin.shell: "tsig-keygen -a {{ item.update_key_algorithm | d('hmac-sha512') }} {{ item.name }}_{{ item.update_keyfile }}_update > {{ bind9_keydir }}/{{ item.update_keyfile }}.private"
   args:
     chdir: "{{ bind9_zonedir }}"
   register: ddns_key
-  changed_when: ddns_key.rc != 0
+  changed_when: ddns_key.rc == 0
   when: item.update_keyfile is defined and not update_keyfile_tmp.stat.exists
 
 - name: Copy DDNS key to control host
   ansible.builtin.fetch:
-    src: "/etc/bind/keys/{{ item.update_keyfile }}.private"
+    src: "{{ bind9_keydir }}/{{ item.update_keyfile }}.private"
     dest: "{{ bind9_local_keydir }}/{{ item.update_keyfile }}.private"
     mode: "0640"
     flat: true


### PR DESCRIPTION
Use bind9_keydir for tsigs as well

Closes #74