### PR TITLE
Allow to configure local static zone files dir

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -139,3 +139,4 @@ bind9_generate_ddns_key: true
 bind9_zonedir: /etc/bind/zones
 bind9_keydir: /etc/bind/keys
 bind9_local_keydir: files/bind/zones
+bind9_local_static_zone_filesdir: bind/zones

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -311,7 +311,7 @@
 
 - name: Install static bind9 zone files
   ansible.builtin.copy:
-    src: bind/zones/db.{{ item.name }}
+    src: "{{ bind9_local_static_zone_filesdir }}/db.{{ item.name }}"
     dest: "{{ bind9_zonedir }}/db.{{ item.name }}"
     owner: root
     group: "{{ bind9_group }}"


### PR DESCRIPTION
Hi @doobry-systemli 

This pull request enables the configuration of a local static zone files directory for enhanced customization and management within the systemli/ansible-role-bind9. This feature provides users with the flexibility to specify a dedicated directory for storing static zone files locally.

**Changes:**

- Modified `defaults/main.yml`:
  Added bind9_local_static_zone_filesdir variable to configure the directory path for local static zone files.
- Modified `tasks/main.yml`:
  Updated the source path for static bind9 zone files to use the newly introduced bind9_local_static_zone_filesdir variable, allowing dynamic customization of the directory path.

This enhancement streamlines the management of static zone files, empowering users to organize and maintain their configurations efficiently.

Best regards
Daniel