### PR TITLE
fix: remove template to include local zones file from config template

### DIFF
--- a/templates/bind/named.conf.local.j2
+++ b/templates/bind/named.conf.local.j2
@@ -2,10 +2,6 @@
 // Do any local configuration here
 //
 
-// Consider adding the 1918 zones here, if they are not used in your
-// organization
-//include "/etc/bind/zones.rfc1918";
-
 {% if bind9_masters|default() %}
 {%   for master in bind9_masters %}
 masters {{ master.name }} {


### PR DESCRIPTION
Bind 9.20 no longer includes this file.