### PR TITLE
Fix booleans and conditionals with latest Ansible versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Features:
 * set vars for your master server, for instance in `host_vars/master_name/vars/XX_bind.yml`, here with an example.com static zones and forwarder:
 
 ```yaml
-bind9_authoritative: yes
+bind9_authoritative: true
 bind9_zones_static:
 - { name: example.com , type=master }
-bind9_forward: yes
+bind9_forward: true
 bind9_forward_servers:
 - 8.8.8.8
 - 4.4.4.4
@@ -49,7 +49,7 @@ bind9_our_neighbors:
 ```yaml
 bind9_zones_static:
 - { name: example.com, type: slave }
-bind9_forward: yes
+bind9_forward: true
 bind9_forward_servers:
 - 8.8.8.8
 - 4.4.4.4

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -125,7 +125,7 @@
   when:
     - bind9_authoritative
     - item.type | default(bind9_zone_type) == 'master'
-    - item.update_keyfile != ""
+    - item.update_keyfile is defined and item.update_keyfile != ""
 
 - name: Copy over DDNS private keys for zones with update_keyfile
   ansible.builtin.copy:
@@ -140,7 +140,7 @@
   when:
     - bind9_authoritative
     - item.type | default(bind9_zone_type) == 'master'
-    - item.update_keyfile != ""
+    - item.update_keyfile is defined and item.update_keyfile != ""
 
 - name: Create dynamic bind9 zone files
   ansible.builtin.template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,7 +62,7 @@
     owner: root
     group: "{{ bind9_group }}"
     mode: "02775"
-  when: bind9_authoritative == "yes"
+  when: bind9_authoritative
 
 - name: Create bind9 directory for master zone includes
   ansible.builtin.file:
@@ -71,7 +71,7 @@
     owner: root
     group: "{{ bind9_group }}"
     mode: "0755"
-  when: bind9_authoritative == "yes"
+  when: bind9_authoritative
 
 - name: Install bind9 authoritative include files
   ansible.builtin.template:
@@ -81,7 +81,7 @@
     group: "{{ bind9_group }}"
     mode: "0644"
   loop: "{{ bind9_authoritative_includes }}"
-  when: bind9_authoritative == "yes"
+  when: bind9_authoritative
   notify:
     - Zone file change
     - Reload bind9
@@ -106,7 +106,7 @@
     owner: "{{ bind9_user }}"
     group: "{{ bind9_group }}"
     mode: 02750
-  when: bind9_authoritative == "yes"
+  when: bind9_authoritative
   tags:
     - role:bind9:ddns
     - role:bind9:dnssec
@@ -123,7 +123,7 @@
   loop_control:
     label: "{{ item.name }}"
   when:
-    - bind9_authoritative == "yes"
+    - bind9_authoritative
     - item.type | default(bind9_zone_type) == 'master'
     - item.update_keyfile != ""
 
@@ -138,7 +138,7 @@
   loop_control:
     label: "{{ item.name }}"
   when:
-    - bind9_authoritative == "yes"
+    - bind9_authoritative
     - item.type | default(bind9_zone_type) == 'master'
     - item.update_keyfile != ""
 
@@ -153,7 +153,7 @@
   loop_control:
     label: "{{ item.name }}"
   when:
-    - bind9_authoritative == "yes"
+    - bind9_authoritative
     - item.type | default(bind9_zone_type) == 'master'
   notify:
     - Zone file change
@@ -173,7 +173,7 @@
   loop_control:
     label: "{{ item.name }}"
   when:
-    - bind9_authoritative == "yes"
+    - bind9_authoritative
     - item.type | default(bind9_zone_type) == 'master'
   notify:
     - Zone file change


### PR DESCRIPTION
Latest Ansible versions convert `yes` to `true`, which lead to `when: bind9_authoritative == "yes"` being evaluated to `false` by default, i.e. all the affected code wasn't executed.

This change converts all `yes` to real booleans.