### PR TITLE
Keep journals and zones in sync, to fix fatal "out of sync" errors

### DIFF
--- a/files/systemd/override.conf
+++ b/files/systemd/override.conf
@@ -1,0 +1,15 @@
+# Systemd override to run '/usr/sbin/rndc sync' before a reload or stop of
+# bind9. This helps to keep journals and zones in sync, to prevent fatal "out
+# of sync" errors.
+#
+# The empty 'ExecReload' and 'ExecStop' clear the defaults, to make the
+# overrides actually possible. Otherwise, the below definitions wouldn't have
+# any effect.
+[Service]
+ExecReload=
+ExecReload=/usr/sbin/rndc sync
+ExecReload=/usr/sbin/rndc reload
+
+ExecStop=
+ExecStop=/usr/sbin/rndc sync
+ExecStop=/usr/sbin/rndc stop

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+
 - name: Restart bind9
   ansible.builtin.service:
     name: bind9

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -193,3 +193,22 @@
   changed_when: False
   vars:
     ansible_ssh_pipelining: True
+
+- name: Create named systemd override directory
+  ansible.builtin.file:
+    mode: "0755"
+    path: /etc/systemd/system/named.service.d
+    state: directory
+  when:
+    - bind9_zone_type == "master" and (bind9_dnssec | bool or bind9_zones_dynamic | length > 0)
+
+- name: Deploy named systemd override.conf to keep journals and zones in sync
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/named.service.d/override.conf
+    mode: "0644"
+    src: systemd/override.conf
+  notify:
+    - Reload systemd
+    - Restart bind9 
+  when:
+    - bind9_zone_type == "master" and (bind9_dnssec | bool or bind9_zones_dynamic | length > 0)


### PR DESCRIPTION
This change adds a systemd override config to run `/usr/sbin/rndc sync`, before reloading or stopping bind9.

The manpage tells:

> This command syncs changes in the journal file for a dynamic zone to the master file. If the `-clean` option is specified, the journal file is also removed. If no zone is specified, then all zones are synced.

However, evidence suggests that this is not only relevant in regards to dynamic zones, but to static ones as well, if these make use of DNSSEC, and are configured to rely on `inline-signing: yes`. Accordingly, `-clean`, as described above, is not in use: deleting the journal files while bind9 signs zones calls for trouble.

Before, depending on the timing of DNSSEC operations, bind9 might have run into fatal `journal rollforward failed: journal out of sync with zone` errors, if trying to load such zones after a reload or (re)start.

These problematic situations are not Ansible-specific; restarting bind9 multiple times in a row might lead to them as well, which is why this fix is implemented via a systemd override, instead of an Ansible handler.

Due to this, it might make sense to report and discuss this upstream or via Debian, not sure where the defaults come from.