### PR TITLE
Make rate limits configurable; minimize ANY query responses

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -112,3 +112,12 @@ bind9_generate_ddns_key: true
 bind9_zonedir: /etc/bind/zones
 bind9_keydir: /etc/bind/keys
 bind9_local_keydir: files/bind/zones
+
+# Bind9 rate limiting
+# bind9_rate_limit:
+#   errors-per-second: 10
+#   log-only: yes
+#   nxdomains-per-second: 10
+#   responses-per-second: 15
+#   slip: 1
+#   window: 5

--- a/templates/bind/named.conf.options.j2
+++ b/templates/bind/named.conf.options.j2
@@ -52,6 +52,17 @@ options {
 	// Look here for DNSSEC keys
 	key-directory "{{ bind9_keydir }}";
 {% endif %}
+
+{% if not bind9_hidden_master | bool %}
+{% if bind9_rate_limit|default({}) %}
+	rate-limit {
+{% for key, value in bind9_rate_limit.items() %}
+		{{ key }} {{ value }};
+{% endfor %}
+	};
+{% endif %}
+	minimal-any yes;
+{% endif %}
 };
 
 {% if bind9_dnssec_policies|default() %}


### PR DESCRIPTION
This change should help to mitigate DNS amplification attacks.